### PR TITLE
Edited mysql connector cdn

### DIFF
--- a/connect-jdbc/docker-compose.yml
+++ b/connect-jdbc/docker-compose.yml
@@ -82,7 +82,7 @@ services:
         # ------------
         # MySQL
         cd /usr/share/java/kafka-connect-jdbc/
-        curl https://cdn.mysql.com/Downloads/Connector-J/mysql-connector-java-8.0.13.tar.gz | tar xz 
+        curl http://ftp.ntu.edu.tw/MySQL/Downloads/Connector-J/mysql-connector-java-8.0.16.tar.gz | tar xz 
         # MS SQL
         cd /usr/share/java/kafka-connect-jdbc/
         curl http://central.maven.org/maven2/com/microsoft/sqlserver/mssql-jdbc/7.0.0.jre8/mssql-jdbc-7.0.0.jre8.jar --output mssql-jdbc-7.0.0.jre8.jar


### PR DESCRIPTION
Signed-off-by: Shajal Ahamed <shajalahamedcse@gmail.com>
Previous cdn for mysql jdbc connector was not working .That's why added a new cdn link.